### PR TITLE
added Path parameter to fix directory issues in pwsh7

### DIFF
--- a/docfx-toc-generator.psd1
+++ b/docfx-toc-generator.psd1
@@ -9,7 +9,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-# RootModule = ''
+RootModule = 'docfx-toc-generator.psm1'
 
 # Version number of this module.
 ModuleVersion = '1.1'

--- a/docfx-toc-generator.psm1
+++ b/docfx-toc-generator.psm1
@@ -96,7 +96,13 @@ function Get-MarkdownSingleTocItem([string]$markdownPath, $tocFolder){
 }
 
 function Build-TocHereRecursive {
-    foreach ($docFolder in Get-RootDocFolder .) {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline=$true)]
+        [string]
+        $Path=$PWD
+    )
+    foreach ($docFolder in Get-RootDocFolder $Path) {
         Write-Host "==== Generating TOC for [$docFolder] ====================" -ForegroundColor DarkGray
         $raw = New-TocYaml $docFolder $docFolder
         $tocFile = ConvertTo-Yaml @($raw)


### PR DESCRIPTION
With just '.', pwsh 7 was running the script on C:\Windows\System32, no mater you current $PWD.